### PR TITLE
IS-9 Added support for PDF signature pages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>se.idsec.signservice.integration</groupId>
   <artifactId>signservice-integration-api</artifactId>
-  <version>1.0.3</version>
+  <version>1.1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>IDsec Solutions :: SignService :: Integration API</name>
@@ -157,7 +157,7 @@
   </build>
 
   <profiles>
-  
+    
     <profile>
       <id>release</id>
 

--- a/src/main/java/se/idsec/signservice/integration/ExtendedSignServiceIntegrationService.java
+++ b/src/main/java/se/idsec/signservice/integration/ExtendedSignServiceIntegrationService.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2019-2020 IDsec Solutions AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package se.idsec.signservice.integration;
+
+import se.idsec.signservice.integration.core.error.InputValidationException;
+import se.idsec.signservice.integration.core.error.SignServiceIntegrationException;
+import se.idsec.signservice.integration.document.TbsDocument;
+import se.idsec.signservice.integration.document.pdf.PdfSignaturePagePreferences;
+import se.idsec.signservice.integration.document.pdf.PreparedPdfDocument;
+import se.idsec.signservice.integration.document.pdf.VisiblePdfSignatureRequirement;
+
+/**
+ * An extension to the interface describing the API for the SignService Integration Service.
+ * 
+ * <p>
+ * This extension is optional to implement, but its purpose is to supply the user of the API with utility methods that
+ * are useful during signature processing.
+ * </p>
+ *
+ * @author Martin Lindström (martin@idsec.se)
+ * @author Stefan Santesson (stefan@idsec.se)
+ */
+public interface ExtendedSignServiceIntegrationService extends SignServiceIntegrationService {
+
+  /**
+   * A utility method that can be used to prepare a PDF document that is to be signed with a PDF signature image with a
+   * PDF signature page holding the signature image(s).
+   * <p>
+   * A PDF signature image can be inserted into a signed PDF document to make the signature information "visible". The
+   * image along with the coordinates that tell where in the PDF document the images should be inserted is represented
+   * using a {@link VisiblePdfSignatureRequirement} object. See {@link TbsDocument#getVisiblePdfSignatureRequirement()}.
+   * </p>
+   * <p>
+   * However, for the generic case, where we may not always know how the PDF document we are signing looks like it may
+   * be tricky to determine where in the document the PDF signature image should be inserted. For those cases, a
+   * dedicated "PDF signature page"may be added to the PDF document before it is added to a {@link TbsDocument} object
+   * and sent as input in a signature operation. By using a PDF signature page whose structure and constitution is well
+   * known it is easy to include a PDF signature image into any PDF document being signed.
+   * </p>
+   * <p>
+   * Also, since a PDF document can be signed several times, using a PDF signature page it is easy to include signature
+   * images for all signatures of the document.
+   * </p>
+   * <p>
+   * The {@code preparePdfSignaturePage} method should invoked before each call to
+   * {@link SignServiceIntegrationService#createSignRequest(SignRequestInput)} where PDF documents with PDF signature
+   * pages is to be used. If a PDF document is to be signed more than once and the PDF signature page supports several
+   * signature images, by default no new PDF signature page is added (see
+   * {@link PdfSignaturePagePreferences#isAddToAlreadySigned()}. Instead, the {@code preparePdfSignaturePage} method
+   * calculates where in the already existing PDF signature page the next signature image will be inserted.
+   * </p>
+   * 
+   * @param policy
+   *          the policy under which the operation is performed (see {@link SignRequestInput#getPolicy()})
+   * @param pdfDocument
+   *          the contents of the PDF document that is to be prepared
+   * @param signaturePagePreferences
+   *          the PDF signature page preferences
+   * @return a PreparedPdfDocument object containing the modified PDF document (if a sign page was added) and the
+   *         VisiblePdfSignatureRequirement telling how a signature image should be added
+   * @throws InputValidationException
+   *           for input validation errors
+   * @throws SignServiceIntegrationException
+   *           for processing errors
+   */
+  PreparedPdfDocument preparePdfSignaturePage(final String policy,
+      final byte[] pdfDocument,
+      final PdfSignaturePagePreferences signaturePagePreferences)
+      throws InputValidationException, SignServiceIntegrationException;
+
+}

--- a/src/main/java/se/idsec/signservice/integration/ExtendedSignServiceIntegrationService.java
+++ b/src/main/java/se/idsec/signservice/integration/ExtendedSignServiceIntegrationService.java
@@ -18,6 +18,7 @@ package se.idsec.signservice.integration;
 import se.idsec.signservice.integration.core.error.InputValidationException;
 import se.idsec.signservice.integration.core.error.SignServiceIntegrationException;
 import se.idsec.signservice.integration.document.TbsDocument;
+import se.idsec.signservice.integration.document.pdf.PdfSignaturePageFullException;
 import se.idsec.signservice.integration.document.pdf.PdfSignaturePagePreferences;
 import se.idsec.signservice.integration.document.pdf.PreparedPdfDocument;
 import se.idsec.signservice.integration.document.pdf.VisiblePdfSignatureRequirement;
@@ -36,17 +37,17 @@ import se.idsec.signservice.integration.document.pdf.VisiblePdfSignatureRequirem
 public interface ExtendedSignServiceIntegrationService extends SignServiceIntegrationService {
 
   /**
-   * A utility method that can be used to prepare a PDF document that is to be signed with a PDF signature image with a
-   * PDF signature page holding the signature image(s).
+   * A utility method that can be used to prepare a PDF document that is to be signed with a PDF signature page holding
+   * the signature image(s).
    * <p>
    * A PDF signature image can be inserted into a signed PDF document to make the signature information "visible". The
-   * image along with the coordinates that tell where in the PDF document the images should be inserted is represented
+   * image along with the coordinates that tell where in the PDF document the image should be inserted is represented
    * using a {@link VisiblePdfSignatureRequirement} object. See {@link TbsDocument#getVisiblePdfSignatureRequirement()}.
    * </p>
    * <p>
-   * However, for the generic case, where we may not always know how the PDF document we are signing looks like it may
-   * be tricky to determine where in the document the PDF signature image should be inserted. For those cases, a
-   * dedicated "PDF signature page"may be added to the PDF document before it is added to a {@link TbsDocument} object
+   * However, for the generic case, where we may not always know how the PDF document that we are signing looks like it
+   * may be tricky to determine where in the document the PDF signature image should be inserted. For those cases, a
+   * dedicated "PDF signature page" may be added to the PDF document before it is added to a {@link TbsDocument} object
    * and sent as input in a signature operation. By using a PDF signature page whose structure and constitution is well
    * known it is easy to include a PDF signature image into any PDF document being signed.
    * </p>
@@ -57,9 +58,8 @@ public interface ExtendedSignServiceIntegrationService extends SignServiceIntegr
    * <p>
    * The {@code preparePdfSignaturePage} method should invoked before each call to
    * {@link SignServiceIntegrationService#createSignRequest(SignRequestInput)} where PDF documents with PDF signature
-   * pages is to be used. If a PDF document is to be signed more than once and the PDF signature page supports several
-   * signature images, by default no new PDF signature page is added (see
-   * {@link PdfSignaturePagePreferences#isAddToAlreadySigned()}. Instead, the {@code preparePdfSignaturePage} method
+   * pages is to be used. If a PDF document is to be signed is signed more than once and the PDF signature page supports
+   * several signature images, no new PDF signature page is added. Instead, the {@code preparePdfSignaturePage} method
    * calculates where in the already existing PDF signature page the next signature image will be inserted.
    * </p>
    * 
@@ -73,12 +73,15 @@ public interface ExtendedSignServiceIntegrationService extends SignServiceIntegr
    *         VisiblePdfSignatureRequirement telling how a signature image should be added
    * @throws InputValidationException
    *           for input validation errors
+   * @throws PdfSignaturePageFullException
+   *           if the PDF document contains more signatures than there is room for in the PDF signature page (and
+   *           {@link PdfSignaturePagePreferences#isFailWhenSignPageFull()} evaluates to true)
    * @throws SignServiceIntegrationException
-   *           for processing errors
+   *           for other processing errors
    */
   PreparedPdfDocument preparePdfSignaturePage(final String policy,
       final byte[] pdfDocument,
       final PdfSignaturePagePreferences signaturePagePreferences)
-      throws InputValidationException, SignServiceIntegrationException;
+      throws InputValidationException, PdfSignaturePageFullException, SignServiceIntegrationException;
 
 }

--- a/src/main/java/se/idsec/signservice/integration/config/IntegrationServiceDefaultConfiguration.java
+++ b/src/main/java/se/idsec/signservice/integration/config/IntegrationServiceDefaultConfiguration.java
@@ -17,6 +17,7 @@ package se.idsec.signservice.integration.config;
 
 import java.util.List;
 
+import se.idsec.signservice.integration.ExtendedSignServiceIntegrationService;
 import se.idsec.signservice.integration.SignRequestInput;
 import se.idsec.signservice.integration.SignResponseProcessingParameters;
 import se.idsec.signservice.integration.SignServiceIntegrationService;
@@ -25,6 +26,7 @@ import se.idsec.signservice.integration.certificate.SigningCertificateRequiremen
 import se.idsec.signservice.integration.core.Extensible;
 import se.idsec.signservice.integration.core.SignatureState;
 import se.idsec.signservice.integration.document.pdf.PdfSignatureImageTemplate;
+import se.idsec.signservice.integration.document.pdf.PdfSignaturePage;
 import se.idsec.signservice.integration.document.pdf.VisiblePdfSignatureRequirement;
 import se.idsec.signservice.integration.security.EncryptionParameters;
 
@@ -138,11 +140,21 @@ public interface IntegrationServiceDefaultConfiguration extends Extensible {
 
   /**
    * A policy may have one, or more, image templates for visible PDF signatures in its configuration. See
-   * {@link PdfSignatureImageTemplate}. This method gets these templates
+   * {@link PdfSignatureImageTemplate}. This method gets these templates.
    * 
    * @return a list of image templates for visible PDF signatures, or null if none exists
    */
   List<? extends PdfSignatureImageTemplate> getPdfSignatureImageTemplates();
+
+  /**
+   * A policy may have one, or more, configured PDF signature pages. See
+   * {@link ExtendedSignServiceIntegrationService#preparePdfSignaturePage(String, byte[], se.idsec.signservice.integration.document.pdf.PdfSignaturePagePreferences)}
+   * for a description of PDF signature pages. The first object in the list is regarded as the default page for the
+   * policy.
+   * 
+   * @return a list of PDF signature pages for the policy, or null if no such pages are defined for the policy
+   */
+  List<? extends PdfSignaturePage> getPdfSignaturePages();
 
   /**
    * Tells whether the SignService Integration Service is running in stateless mode or not.

--- a/src/main/java/se/idsec/signservice/integration/core/error/SignServiceIntegrationException.java
+++ b/src/main/java/se/idsec/signservice/integration/core/error/SignServiceIntegrationException.java
@@ -115,14 +115,11 @@ public abstract class SignServiceIntegrationException extends Exception {
 
   /**
    * Override this method if a subclass is tied to a specific error category.
-   * <p>
-   * Default implementation returns {@code null}.
-   * </p>
    *
    * @return the error category for this exception
    */
   protected ErrorCode.Category getCategory() {
-    return null;
+    return this.errorCode != null ? new ErrorCode.Category(this.errorCode.getCategory()) : null;
   }
 
 }

--- a/src/main/java/se/idsec/signservice/integration/document/pdf/PdfSignatureImageTemplate.java
+++ b/src/main/java/se/idsec/signservice/integration/document/pdf/PdfSignatureImageTemplate.java
@@ -40,8 +40,7 @@ import se.idsec.signservice.integration.core.ObjectBuilder;
  * <ul>
  * <li><b>signerName</b> - Displays the signer name information in the visible PDF signature. The caller does not
  * specify the name directly in the request. Instead the user attribute names that will hold these values after user
- * authentication is given. See
- * {@link VisiblePdfSignatureRequirement#setSignerName(se.idsec.signservice.integration.document.pdf.VisiblePdfSignatureRequirement.SignerName)}.</li>
+ * authentication is given. See {@link VisiblePdfSignatureUserInformation#setSignerName(se.idsec.signservice.integration.document.pdf.VisiblePdfSignatureUserInformation.SignerName)}.</li>
  * <li><b>signingTime</b> - Includes a time stamp telling when the document was signed in the PDF. The caller does not
  * provide this information. Instead the SignService Integration Service includes this information if the
  * {@link #isIncludeSigningTime()} is set.</li>

--- a/src/main/java/se/idsec/signservice/integration/document/pdf/PdfSignaturePage.java
+++ b/src/main/java/se/idsec/signservice/integration/document/pdf/PdfSignaturePage.java
@@ -1,0 +1,301 @@
+/*
+ * Copyright 2019-2020 IDsec Solutions AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package se.idsec.signservice.integration.document.pdf;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import se.idsec.signservice.integration.core.Extensible;
+import se.idsec.signservice.integration.core.Extension;
+import se.idsec.signservice.integration.core.ObjectBuilder;
+
+/**
+ * Representation of a "PDF signature page".
+ * <p>
+ * A signature page may be used when signing PDF documents together with "PDF visible signatures" (see
+ * {@link PdfSignatureImageTemplate}). In those cases a customized "signature page" may be added to the PDF document
+ * before it is signed. This page will then hold the PDF signature image, or images if the document is signed multiple
+ * times.
+ * </p>
+ * <p>
+ * The reason for using a PDF signature page is that we can sign any type of PDF document and still be sure that the PDF
+ * signature image ends up in the correct place. If no PDF signature page is used we have to have prior knowledge about
+ * the PDF document that is about to be signed so that we know where to place the PDF signature image.
+ * </p>
+ *
+ * @author Martin Lindström (martin@idsec.se)
+ * @author Stefan Santesson (stefan@idsec.se)
+ */
+@ToString
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PdfSignaturePage implements Extensible {
+
+  /**
+   * The unique ID for this PDF signature page.
+   * 
+   * @param id
+   *          unique ID
+   * @return the ID
+   */
+  @Getter
+  @Setter
+  private String id;
+
+  /**
+   * The contents of the PDF document that holds the PDF signature page.
+   * 
+   * @param contents
+   *          the byte contents of the PDF document in Base64 encoded format
+   * @return the byte contents of the PDF document in Base64 encoded format
+   * @see {@link #getResource()} and {@link #setResource(String)}
+   */
+  @Setter
+  @Getter
+  private String contents;
+
+  /**
+   * A resource string that points at the PDF document that holds the PDF signature page.
+   * 
+   * @param resource
+   *          the resource that holds the PDF signature page document
+   * @return the resource that holds the PDF signature page document
+   * @see {@link #getContents()} and {@link #setContents(String)}
+   */
+  @Setter
+  @Getter
+  private String resource;
+
+  /**
+   * Tells how many PDF signature images that may be displayed in the PDF signature page. The default is {@code 1}.
+   * 
+   * @param maxSignatureImages
+   *          the maximum number of PDF signature images this page can contain
+   * @return the maximum number of PDF signature images this page can contain
+   */
+  @Getter
+  @Setter
+  @Builder.Default
+  private Integer maxSignatureImages = 1;
+
+  /**
+   * If it should be possible to add PDF sign images in several rows to this sign page document the {@code rows}
+   * attribute should assigned to the desired number of rows. The default is {@code 1}.
+   * 
+   * @param rows
+   *          the number of rows of PDF sign images this sign page supports
+   * @return the number of rows of PDF sign images this sign page supports
+   */
+  @Getter
+  @Setter
+  @Builder.Default
+  private Integer rows = 1;
+
+  /**
+   * If it should be possible to add PDF sign images in several columns to this sign page document the {@code columns}
+   * attribute should assigned to the desired number of columns. The default is {@code 1}.
+   * 
+   * @param columns
+   *          the number of columns of PDF sign images this sign page supports
+   * @return the number of columns of PDF sign images this sign page supports
+   */
+  @Getter
+  @Setter
+  @Builder.Default
+  private Integer columns = 1;
+
+  /**
+   * A unique reference of the signature template image that is inserted into this PDF signature page. See
+   * {@link PdfSignatureImageTemplate}.
+   * 
+   * @param signatureImageReference
+   *          the unique reference of the signature image template
+   * @return the unique reference of the signature image template
+   * @see PdfSignatureImageTemplate
+   * @see VisiblePdfSignatureRequirement#getTemplateImageRef()
+   */
+  @Getter
+  @Setter
+  protected String signatureImageReference;
+
+  /**
+   * Tells where in the PDF signature page the PDF signature image(s) should be inserted.
+   * 
+   * @param signatureImagePlacement
+   *          where in the PDF signature page the PDF signature image(s) should be inserted
+   * @return where in the PDF signature page the PDF signature image(s) should be inserted
+   */
+  @Getter
+  @Setter
+  private PdfSignatureImagePlacement signatureImagePlacement;
+
+  /** Extensions for the object. */
+  private Extension extension;
+
+  /** {@inheritDoc} */
+  @Override
+  public Extension getExtension() {
+    return this.extension;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void setExtension(final Extension extension) {
+    this.extension = extension;
+  }
+
+  /**
+   * Builder for {@code PdfSignPagePreferences} objects.
+   */
+  public static class PdfSignaturePageBuilder implements ObjectBuilder<PdfSignaturePage> {
+    private Integer maxSignatureImages = 1;
+    private Integer rows = 1;
+    private Integer columns = 1;
+
+    // Lombok
+  }
+
+  /**
+   * Representation of where in a PDF signature page PDF signature images should be inserted.
+   */
+  @ToString
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class PdfSignatureImagePlacement implements Extensible {
+
+    /**
+     * The X coordinate position (in pixels) of where the first PDF visible signature image should be inserted on the
+     * PDF signature page.
+     * 
+     * @param xPosition
+     *          the initial X coordinate position (in pixels)
+     * @return the initial X coordinate position (in pixels)
+     */
+    @Getter
+    @Setter
+    private Integer xPosition;
+
+    /**
+     * The Y coordinate position (in pixels) of where the first PDF visible signature image should be inserted on the
+     * PDF signature page.
+     * 
+     * @param yPosition
+     *          the initial Y coordinate position (in pixels)
+     * @return the initial Y coordinate position (in pixels)
+     */
+    @Getter
+    @Setter
+    private Integer yPosition;
+
+    /**
+     * The scale of the final visible signature image expressed as zoom percentage. The value -100 represents a 0 sized
+     * image, the value 0 represents unaltered size, the value 100 double size and so on. If {@code null}, 0 is assumed.
+     * 
+     * @param scale
+     *          the scale of the final visible signature image
+     * @return the scale of the final visible signature image
+     */
+    @Getter
+    @Setter
+    @Builder.Default
+    private Integer scale = 0;
+
+    /**
+     * If the PDF signature page supports more than one column (see {@link PdfSignaturePage#getColumns()}) the
+     * {@code xIncrement} property tells how many pixels that should be added to the previously used {@code xPosition}
+     * when inserting a PDF signature image in a new column.
+     * <p>
+     * Note: If the PDF signature page only supports one column this property is ignored.
+     * </p>
+     * 
+     * @param xIncrement
+     *          the number of pixels that should be added to the previously used xPosition when inserting a PDF
+     *          signature image in a new column
+     * @return the number of pixels that should be added to the previously used xPosition when inserting a PDF signature
+     *         image in a new column
+     */
+    @Getter
+    @Setter
+    private Integer xIncrement;
+
+    /**
+     * If the PDF signature page supports more than one row (see {@link PdfSignaturePage#getRows()}) the
+     * {@code yIncrement} property tells how many pixels that should be added to the previously used {@code yPosition}
+     * when inserting a PDF signature image in a new row.
+     * <p>
+     * Note: If the PDF signature page only supports one row this property is ignored.
+     * </p>
+     * 
+     * @param yIncrement
+     *          the number of pixels that should be added to the previously used yPosition when inserting a PDF
+     *          signature image in a new row
+     * @return the number of pixels that should be added to the previously used yPosition when inserting a PDF signature
+     *         image in a new row
+     */
+    @Getter
+    @Setter
+    private Integer yIncrement;
+
+    /**
+     * If the PDF signature page document (see {@link PdfSignaturePage#getContents()}) contains more than one page it is
+     * possible to use the {@code page} attribute to tell where the PDF signature image(s) should be inserted. A value
+     * of 1 represents the first page and a value of 0 represents the last page. The default is {@code 1}.
+     * <p>
+     * Note: It is only possible to have PDF signature images inserted into <b>one</b> page of the PDF signature page
+     * document.
+     * </p>
+     * 
+     * @param page
+     *          the page number in the document where sign image(s) should be inserted
+     * @return the page number in the document where sign image(s) should be inserted
+     */
+    @Getter
+    @Setter
+    @Builder.Default
+    private Integer page = 1;
+
+    /** Extensions for the object. */
+    private Extension extension;
+
+    /** {@inheritDoc} */
+    @Override
+    public Extension getExtension() {
+      return this.extension;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setExtension(final Extension extension) {
+      this.extension = extension;
+    }
+
+    /**
+     * Builder for {@code PdfSignatureImagePlacement} objects.
+     */
+    public static class PdfSignatureImagePlacementBuilder implements ObjectBuilder<PdfSignatureImagePlacement> {
+      private Integer page = 1;
+      private Integer scale = 0;
+
+      // Lombok
+    }
+  }
+
+}

--- a/src/main/java/se/idsec/signservice/integration/document/pdf/PdfSignaturePage.java
+++ b/src/main/java/se/idsec/signservice/integration/document/pdf/PdfSignaturePage.java
@@ -61,11 +61,13 @@ public class PdfSignaturePage implements Extensible {
 
   /**
    * The contents of the PDF document that holds the PDF signature page.
+   * <p>
+   * See also {@link #getResource()} and {@link #setResource(String)}.
+   * </p>
    * 
    * @param contents
    *          the byte contents of the PDF document in Base64 encoded format
    * @return the byte contents of the PDF document in Base64 encoded format
-   * @see {@link #getResource()} and {@link #setResource(String)}
    */
   @Setter
   @Getter
@@ -73,11 +75,17 @@ public class PdfSignaturePage implements Extensible {
 
   /**
    * A resource string that points at the PDF document that holds the PDF signature page.
+   * <p>
+   * Note: The Spring Framework style of representing a resource must be supported by implementations. For example:
+   * {@code classpath:xyz.pdf} and {@code file:///path/xyz.pdf}.
+   * </p>
+   * <p>
+   * See also {@link #getContents()} and {@link #setContents(String)}.
+   * </p>
    * 
    * @param resource
    *          the resource that holds the PDF signature page document
    * @return the resource that holds the PDF signature page document
-   * @see {@link #getContents()} and {@link #setContents(String)}
    */
   @Setter
   @Getter
@@ -136,15 +144,15 @@ public class PdfSignaturePage implements Extensible {
   protected String signatureImageReference;
 
   /**
-   * Tells where in the PDF signature page the PDF signature image(s) should be inserted.
+   * Configuration that tells where in the PDF signature page the PDF signature image(s) should be inserted.
    * 
-   * @param signatureImagePlacement
-   *          where in the PDF signature page the PDF signature image(s) should be inserted
-   * @return where in the PDF signature page the PDF signature image(s) should be inserted
+   * @param imagePlacementConfiguration
+   *          configuration for where in the PDF signature page the PDF signature image(s) should be inserted
+   * @return configuration for where in the PDF signature page the PDF signature image(s) should be inserted
    */
   @Getter
   @Setter
-  private PdfSignatureImagePlacement signatureImagePlacement;
+  private PdfSignatureImagePlacementConfiguration imagePlacementConfiguration;
 
   /** Extensions for the object. */
   private Extension extension;
@@ -173,13 +181,13 @@ public class PdfSignaturePage implements Extensible {
   }
 
   /**
-   * Representation of where in a PDF signature page PDF signature images should be inserted.
+   * Representation of the configuration of where in a PDF signature page PDF signature images should be inserted.
    */
   @ToString
   @Builder
   @NoArgsConstructor
   @AllArgsConstructor
-  public static class PdfSignatureImagePlacement implements Extensible {
+  public static class PdfSignatureImagePlacementConfiguration implements Extensible {
 
     /**
      * The X coordinate position (in pixels) of where the first PDF visible signature image should be inserted on the
@@ -288,9 +296,9 @@ public class PdfSignaturePage implements Extensible {
     }
 
     /**
-     * Builder for {@code PdfSignatureImagePlacement} objects.
+     * Builder for {@code PdfSignatureImagePlacementConfiguration} objects.
      */
-    public static class PdfSignatureImagePlacementBuilder implements ObjectBuilder<PdfSignatureImagePlacement> {
+    public static class PdfSignatureImagePlacementConfigurationBuilder implements ObjectBuilder<PdfSignatureImagePlacementConfiguration> {
       private Integer page = 1;
       private Integer scale = 0;
 

--- a/src/main/java/se/idsec/signservice/integration/document/pdf/PdfSignaturePageFullException.java
+++ b/src/main/java/se/idsec/signservice/integration/document/pdf/PdfSignaturePageFullException.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2019-2020 IDsec Solutions AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package se.idsec.signservice.integration.document.pdf;
+
+import se.idsec.signservice.integration.ExtendedSignServiceIntegrationService;
+import se.idsec.signservice.integration.core.error.ErrorCode;
+import se.idsec.signservice.integration.core.error.SignServiceIntegrationException;
+
+/**
+ * An exception that is reported by
+ * {@link ExtendedSignServiceIntegrationService#preparePdfSignaturePage(String, byte[], PdfSignaturePagePreferences)} if
+ * there is no more room in a PDF signature page to insert a PDF signature image.
+ *
+ * @author Martin Lindström (martin@idsec.se)
+ * @author Stefan Santesson (stefan@idsec.se)
+ */
+public class PdfSignaturePageFullException extends SignServiceIntegrationException {
+  
+  /** The error code for this exception. */
+  public static final ErrorCode errorCode = ErrorCode.error("document", "too-many-signimages");
+
+  /** For serializing. */
+  private static final long serialVersionUID = -585085178132381590L;
+
+  /**
+   * Constructor.
+   *
+   * @param message
+   *          the error message
+   */
+  public PdfSignaturePageFullException(final String message) {
+    super(errorCode, message);
+  }
+  
+  /**
+   * Constructor.
+   *
+   * @param message
+   *          the error message
+   * @param cause
+   *          the cause of the error
+   */  
+  public PdfSignaturePageFullException(final String message, final Throwable cause) {
+    super(errorCode, message, cause);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public int getHttpStatus() {
+    return 403;
+  }
+
+}

--- a/src/main/java/se/idsec/signservice/integration/document/pdf/PdfSignaturePagePreferences.java
+++ b/src/main/java/se/idsec/signservice/integration/document/pdf/PdfSignaturePagePreferences.java
@@ -77,27 +77,41 @@ public class PdfSignaturePagePreferences implements Extensible {
   private PdfSignaturePage signaturePage;
 
   /**
-   * A template for how to generate a {@link VisiblePdfSignatureRequirement} object. Using the template values (signer
-   * name and other field values) and combining with information regarding the PDF signature image found in
-   * {@link #getSignaturePageReference()} or {@link #getSignaturePage()} a complete
-   * {@link VisiblePdfSignatureRequirement} object can be created.
+   * The input regarding the user information that is to be used when generating a
+   * {@link VisiblePdfSignatureRequirement} object. Using the object's values (signer name and other field values) and
+   * combining with information regarding the PDF signature image found in {@link #getSignaturePageReference()} or
+   * {@link #getSignaturePage()} a complete {@link VisiblePdfSignatureRequirement} object can be created.
    * 
-   * @param visiblePdfSignatureTemplate
-   *          template for creating a VisiblePdfSignatureRequirement object
-   * @return a template for creating a VisiblePdfSignatureRequirement object
+   * @param visiblePdfSignatureUserInformation
+   *          user information input for creating a VisiblePdfSignatureRequirement object
+   * @return user information input for creating a VisiblePdfSignatureRequirement object
    */
   @Getter
   @Setter
-  private VisiblePdfSignatureRequirementTemplate visiblePdfSignatureTemplate;
+  private VisiblePdfSignatureUserInformation visiblePdfSignatureUserInformation;
 
   /**
-   * The {@code addToAlreadySigned} property tells whether or not we should add the given signature page to a PDF
-   * document that already has been signed (and possibly already has a signature page). The default is {@code false}.
+   * A {@link PdfSignaturePage} has a limit on how many PDF signature images it can hold (see
+   * {@link PdfSignaturePage#getMaxSignatureImages()}). If
+   * {@link ExtendedSignServiceIntegrationService#preparePdfSignaturePage(String, byte[], PdfSignaturePagePreferences)}
+   * is invoked with a PDF document that contains a number of signature that equals or exceeds the maximum number of
+   * allowed signature images ({@link PdfSignaturePage#getMaxSignatureImages()}) for the current PDF signature page the
+   * {@code failWhenSignPageFull} property tells whether {@code preparePdfSignaturePage} should fail
+   * ({@link PdfSignaturePageFullException}) or whether it should allow proceeding with the signature operation where no
+   * PDF signature image is inserted (in that case the resulting {@link PreparedPdfDocument} will contain a "null"
+   * {@link VisiblePdfSignatureRequirement} (see
+   * {@link VisiblePdfSignatureRequirement#createNullVisiblePdfSignatureRequirement()}).
+   * 
+   * @param failWhenSignPageFull
+   *          whether processing should fail or not when the PDF signature page does not have room for any more sign
+   *          images (the default is true)
+   * @return whether processing should fail or not when the PDF signature page does not have room for any more sign
+   *         images
    */
   @Getter
   @Setter
   @Builder.Default
-  private boolean addToAlreadySigned = false;
+  private boolean failWhenSignPageFull = true;
 
   /**
    * Tells where in a PDF document the PDF signature page should be inserted. A value of 1 represents the first page and
@@ -131,7 +145,7 @@ public class PdfSignaturePagePreferences implements Extensible {
    * Builder for {@code PdfSignaturePagePreferences} objects.
    */
   public static class PdfSignaturePagePreferencesBuilder implements ObjectBuilder<PdfSignaturePagePreferences> {
-    private boolean addToAlreadySigned = false;
+    private boolean failWhenSignPageFull = true;
 
     // Lombok
   }

--- a/src/main/java/se/idsec/signservice/integration/document/pdf/PdfSignaturePagePreferences.java
+++ b/src/main/java/se/idsec/signservice/integration/document/pdf/PdfSignaturePagePreferences.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2019-2020 IDsec Solutions AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package se.idsec.signservice.integration.document.pdf;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import se.idsec.signservice.integration.ExtendedSignServiceIntegrationService;
+import se.idsec.signservice.integration.core.Extensible;
+import se.idsec.signservice.integration.core.Extension;
+import se.idsec.signservice.integration.core.ObjectBuilder;
+
+/**
+ * Representation of preferences for adding or modifying a {@link PdfSignaturePage}. See
+ * {@link ExtendedSignServiceIntegrationService#preparePdfSignaturePage(String, byte[], PdfSignaturePagePreferences)}.
+ *
+ * @author Martin Lindström (martin@idsec.se)
+ * @author Stefan Santesson (stefan@idsec.se)
+ */
+@ToString
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PdfSignaturePagePreferences implements Extensible {
+
+  /**
+   * Reference to a PDF signature page to be inserted (see {@link PdfSignaturePage#getId()}). This signature page must
+   * be configured within the current policy. As an alternative to giving the reference an entire
+   * {@link PdfSignaturePage} (see {@link #setSignaturePage(PdfSignaturePage)}).
+   * 
+   * <p>
+   * It is an error to specify both {@code signaturePageReference} and {@code signaturePage}. If neither
+   * {@code signaturePageReference} or {@code signaturePage} is given, the default signature page for the policy will be
+   * used, and if no signature page has been configured for the policy an error is reported.
+   * </p>
+   * 
+   * @param signaturePageReference
+   *          the reference of the PDF signature page to be inserted
+   * @return a reference of the PDF signature page to be inserted
+   */
+  @Getter
+  @Setter
+  private String signaturePageReference;
+
+  /**
+   * As an alternative to specifying a {@code signPageReference} (see {@link #setSignaturePageReference(String)}) the
+   * actual sign page can be provided in the preferences.
+   * 
+   * <p>
+   * It is an error to specify both {@code signaturePageReference} and {@code signaturePage}. If neither
+   * {@code signaturePageReference} or {@code signaturePage} is given, the default signature page for the policy will be
+   * used, and if no signature page has been configured for the policy an error is reported.
+   * </p>
+   * 
+   * @param signaturePage
+   *          the PDF signature page to add
+   * @return the PDF signature page to add
+   */
+  @Getter
+  @Setter
+  private PdfSignaturePage signaturePage;
+
+  /**
+   * A template for how to generate a {@link VisiblePdfSignatureRequirement} object. Using the template values (signer
+   * name and other field values) and combining with information regarding the PDF signature image found in
+   * {@link #getSignaturePageReference()} or {@link #getSignaturePage()} a complete
+   * {@link VisiblePdfSignatureRequirement} object can be created.
+   * 
+   * @param visiblePdfSignatureTemplate
+   *          template for creating a VisiblePdfSignatureRequirement object
+   * @return a template for creating a VisiblePdfSignatureRequirement object
+   */
+  @Getter
+  @Setter
+  private VisiblePdfSignatureRequirementTemplate visiblePdfSignatureTemplate;
+
+  /**
+   * The {@code addToAlreadySigned} property tells whether or not we should add the given signature page to a PDF
+   * document that already has been signed (and possibly already has a signature page). The default is {@code false}.
+   */
+  @Getter
+  @Setter
+  @Builder.Default
+  private boolean addToAlreadySigned = false;
+
+  /**
+   * Tells where in a PDF document the PDF signature page should be inserted. A value of 1 represents the first page and
+   * a value of 0 (or {@code null}) represents the last page. The last page is the default.
+   * 
+   * @param insertPageAt
+   *          the page number in a PDF document where the PDF signature page should be inserted
+   * @return the page number in a PDF document where the PDF signature page should be inserted
+   */
+  @Getter
+  @Setter
+  @Builder.Default
+  private Integer insertPageAt = 0;
+
+  /** Extensions for the object. */
+  private Extension extension;
+
+  /** {@inheritDoc} */
+  @Override
+  public Extension getExtension() {
+    return this.extension;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void setExtension(final Extension extension) {
+    this.extension = extension;
+  }
+
+  /**
+   * Builder for {@code PdfSignaturePagePreferences} objects.
+   */
+  public static class PdfSignaturePagePreferencesBuilder implements ObjectBuilder<PdfSignaturePagePreferences> {
+    private boolean addToAlreadySigned = false;
+
+    // Lombok
+  }
+
+}

--- a/src/main/java/se/idsec/signservice/integration/document/pdf/PreparePdfSignaturePageInput.java
+++ b/src/main/java/se/idsec/signservice/integration/document/pdf/PreparePdfSignaturePageInput.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2019-2020 IDsec Solutions AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package se.idsec.signservice.integration.document.pdf;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import se.idsec.signservice.integration.ExtendedSignServiceIntegrationService;
+import se.idsec.signservice.integration.core.Extensible;
+import se.idsec.signservice.integration.core.Extension;
+import se.idsec.signservice.integration.core.ObjectBuilder;
+
+/**
+ * Class that represents the input to
+ * {@link ExtendedSignServiceIntegrationService#preparePdfSignaturePage(String, byte[], PdfSignaturePagePreferences)}
+ * when implemented as a REST endpoint.
+ *
+ * @author Martin Lindström (martin@idsec.se)
+ * @author Stefan Santesson (stefan@idsec.se)
+ */
+@ToString
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
+public class PreparePdfSignaturePageInput implements Extensible {
+
+  /**
+   * The contents of the PDF document that is to be prepared in Base64 encoded format.
+   * 
+   * @param pdfDocument
+   *          the PDF document (in Base64 encoded format)
+   * @return the PDF document (in Base64 encoded format)
+   */
+  @Getter
+  @Setter
+  private String pdfDocument;
+
+  /**
+   * The preferences of how to prepare the PDF document for a PDF signature page and signature image.
+   * 
+   * @param signaturePagePreferences
+   *          preferences of how to prepare the PDF document for a PDF signature page and signature image
+   * @return preferences of how to prepare the PDF document for a PDF signature page and signature image
+   */
+  @Getter
+  @Setter
+  private PdfSignaturePagePreferences signaturePagePreferences;
+
+  /** Extensions for the object. */
+  private Extension extension;
+
+  /** {@inheritDoc} */
+  @Override
+  public Extension getExtension() {
+    return this.extension;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void setExtension(final Extension extension) {
+    this.extension = extension;
+  }
+
+  /**
+   * Builder for {@link PreparePdfSignaturePageInput}.
+   */
+  public static class PreparePdfSignaturePageInputBuilder implements ObjectBuilder<PreparePdfSignaturePageInput> {
+    // Lombok
+  }
+
+}

--- a/src/main/java/se/idsec/signservice/integration/document/pdf/PreparedPdfDocument.java
+++ b/src/main/java/se/idsec/signservice/integration/document/pdf/PreparedPdfDocument.java
@@ -32,7 +32,7 @@ import se.idsec.signservice.integration.document.TbsDocument;
  * The {@code PreparedPdfDocument} is the representation of the object that is returned from
  * {@link ExtendedSignServiceIntegrationService#preparePdfSignaturePage(String, byte[], PdfSignaturePagePreferences)}.
  * The {@code preparePdfSignaturePage} method is used to setup a PDF document along with its visible signature
- * requirements ({@link VisiblePdfSignatureRequirement) before
+ * requirements ({@link VisiblePdfSignatureRequirement}) before
  * {@link SignServiceIntegrationService#createSignRequest(se.idsec.signservice.integration.SignRequestInput)} is called.
  *
  * @author Martin Lindström (martin@idsec.se)

--- a/src/main/java/se/idsec/signservice/integration/document/pdf/PreparedPdfDocument.java
+++ b/src/main/java/se/idsec/signservice/integration/document/pdf/PreparedPdfDocument.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2019-2020 IDsec Solutions AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package se.idsec.signservice.integration.document.pdf;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import se.idsec.signservice.integration.ExtendedSignServiceIntegrationService;
+import se.idsec.signservice.integration.SignServiceIntegrationService;
+import se.idsec.signservice.integration.core.Extensible;
+import se.idsec.signservice.integration.core.Extension;
+import se.idsec.signservice.integration.core.ObjectBuilder;
+import se.idsec.signservice.integration.document.TbsDocument;
+
+/**
+ * The {@code PreparedPdfDocument} is the representation of the object that is returned from
+ * {@link ExtendedSignServiceIntegrationService#preparePdfSignaturePage(String, byte[], PdfSignaturePagePreferences)}.
+ * The {@code preparePdfSignaturePage} method is used to setup a PDF document along with its visible signature
+ * requirements ({@link VisiblePdfSignatureRequirement) before
+ * {@link SignServiceIntegrationService#createSignRequest(se.idsec.signservice.integration.SignRequestInput)} is called.
+ *
+ * @author Martin Lindström (martin@idsec.se)
+ * @author Stefan Santesson (stefan@idsec.se)
+ */
+@ToString
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PreparedPdfDocument implements Extensible {
+
+  /**
+   * If the PDF document passed to
+   * {@link ExtendedSignServiceIntegrationService#preparePdfSignaturePage(String, byte[], PdfSignaturePagePreferences)}
+   * was updated with a PDF signature page this property holds the updated PDf document (in its Base64 encoded form).
+   * <p>
+   * If the property is {@code null} it means that the PDF document was not modified by {@code preparePdfSignaturePage}.
+   * </p>
+   * 
+   * @param updatedPdfDocument
+   *          updated PDF document (in Base64 encoded form)
+   * @return the updated PDF document (in Base64 encoded form) or null if the initial PDF document was not updated
+   */
+  @Setter
+  @Getter
+  private String updatedPdfDocument;
+
+  /**
+   * The resulting {@link VisiblePdfSignatureRequirement} object that should be passed as a property in the
+   * {@link TbsDocument} holding the PDF document that is passed to
+   * {@link SignServiceIntegrationService#createSignRequest(se.idsec.signservice.integration.SignRequestInput)}.
+   * 
+   * @param visiblePdfSignatureRequirement
+   *          a VisiblePdfSignatureRequirement object to be used in a TbsDocument for the PDF document that is about to
+   *          be signed with a signature image
+   * @return a VisiblePdfSignatureRequirement object to be used in a TbsDocument for the PDF document that is about to
+   *         be signed with a signature image
+   */
+  @Setter
+  @Getter
+  private VisiblePdfSignatureRequirement visiblePdfSignatureRequirement;
+
+  /** Extensions for the object. */
+  private Extension extension;
+
+  /** {@inheritDoc} */
+  @Override
+  public Extension getExtension() {
+    return this.extension;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void setExtension(final Extension extension) {
+    this.extension = extension;
+  }
+
+  /**
+   * Builder for {@code PreparedPdfDocument} objects.
+   */
+  public static class PreparedPdfDocumentBuilder implements ObjectBuilder<PreparedPdfDocument> {
+
+    // Lombok
+  }
+
+}

--- a/src/main/java/se/idsec/signservice/integration/document/pdf/VisiblePdfSignatureRequirement.java
+++ b/src/main/java/se/idsec/signservice/integration/document/pdf/VisiblePdfSignatureRequirement.java
@@ -38,7 +38,7 @@ import se.idsec.signservice.integration.core.ObjectBuilder;
 @ToString
 @NoArgsConstructor
 @AllArgsConstructor
-public class VisiblePdfSignatureRequirement extends VisiblePdfSignatureRequirementTemplate {
+public class VisiblePdfSignatureRequirement extends VisiblePdfSignatureUserInformation {
 
   /** Constant for an extension that denotes a "null" visible PDF signature requirement. */
   public static final String NULL_INDICATOR_EXTENSION = "nullVisiblePdfSignatureRequirement";

--- a/src/main/java/se/idsec/signservice/integration/document/pdf/VisiblePdfSignatureRequirement.java
+++ b/src/main/java/se/idsec/signservice/integration/document/pdf/VisiblePdfSignatureRequirement.java
@@ -15,7 +15,7 @@
  */
 package se.idsec.signservice.integration.document.pdf;
 
-import java.util.List;
+import java.util.HashMap;
 import java.util.Map;
 
 import lombok.AllArgsConstructor;
@@ -23,12 +23,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import lombok.Singular;
 import lombok.ToString;
-import se.idsec.signservice.integration.authentication.AuthnRequirements;
-import se.idsec.signservice.integration.authentication.SignerIdentityAttribute;
 import se.idsec.signservice.integration.config.IntegrationServiceDefaultConfiguration;
-import se.idsec.signservice.integration.core.Extensible;
 import se.idsec.signservice.integration.core.Extension;
 import se.idsec.signservice.integration.core.ObjectBuilder;
 
@@ -40,10 +36,9 @@ import se.idsec.signservice.integration.core.ObjectBuilder;
  * @author Stefan Santesson (stefan@idsec.se)
  */
 @ToString
-@Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class VisiblePdfSignatureRequirement implements Extensible {
+public class VisiblePdfSignatureRequirement extends VisiblePdfSignatureRequirementTemplate {
 
   /** Constant for an extension that denotes a "null" visible PDF signature requirement. */
   public static final String NULL_INDICATOR_EXTENSION = "nullVisiblePdfSignatureRequirement";
@@ -59,20 +54,6 @@ public class VisiblePdfSignatureRequirement implements Extensible {
   @Getter
   @Setter
   private String templateImageRef;
-
-  /**
-   * Name of the signer to be represented in the visible image. This is typically a name of the signer but any suitable
-   * identity attribute value may be specified to be part of the signer name. This value is analogous to, and should
-   * hold the same value as, a present Name entry in the PDF signature dictionary. If the image template referenced
-   * requires a value for signerName, this field is mandatory, otherwise it is optional.
-   * 
-   * @param signerName
-   *          the signer name
-   * @return the signer name
-   */
-  @Getter
-  @Setter
-  private SignerName signerName;
 
   /**
    * The X coordinate position (in pixels) of the PDF visible signature image in the PDF document.
@@ -121,22 +102,6 @@ public class VisiblePdfSignatureRequirement implements Extensible {
   private Integer page;
 
   /**
-   * Apart from the signer name and signing date, a template may use other fields. This map provides the requested
-   * fields and values.
-   * 
-   * @param fieldValues
-   *          a map of fields and their values
-   * @return a map of fields and their values
-   */
-  @Getter
-  @Setter
-  @Singular
-  private Map<String, String> fieldValues;
-
-  /** Extensions for the object. */
-  private Extension extension;
-
-  /**
    * Creates a "null" visible PDF signature requirement. This may be used in cases where the signature policy that is
    * being used has a default visible PDF signature requirement (see
    * {@link IntegrationServiceDefaultConfiguration#getDefaultVisiblePdfSignatureRequirement()}) but we, for some reason,
@@ -151,16 +116,16 @@ public class VisiblePdfSignatureRequirement implements Extensible {
     return nullRequirement;
   }
 
-  /** {@inheritDoc} */
-  @Override
-  public void setExtension(final Extension extension) {
-    this.extension = extension;
-  }
-
-  /** {@inheritDoc} */
-  @Override
-  public Extension getExtension() {
-    return this.extension;
+  @Builder
+  public VisiblePdfSignatureRequirement(final SignerName signerName, final Map<String, String> fieldValues, 
+      final Extension extension, final String templateImageRef, final Integer xPosition, final Integer yPosition, 
+      final Integer scale, final Integer page) {
+    super(signerName, fieldValues, extension);
+    this.templateImageRef = templateImageRef;
+    this.xPosition = xPosition;
+    this.yPosition = yPosition;
+    this.scale = scale;
+    this.page = page;
   }
 
   /**
@@ -168,54 +133,16 @@ public class VisiblePdfSignatureRequirement implements Extensible {
    */
   public static class VisiblePdfSignatureRequirementBuilder implements ObjectBuilder<VisiblePdfSignatureRequirement> {
     // Lombok
-  }
-
-  /**
-   * Class representing the input needed to display the signer name in a visible PDF signature.
-   */
-  @ToString
-  @Builder
-  @NoArgsConstructor
-  @AllArgsConstructor
-  public static class SignerName {
-
-    /**
-     * A list of attribute names that refer to some, or all, attributes supplied in
-     * {@link AuthnRequirements#setRequestedSignerAttributes(List)} that are the requirements that the signer requires
-     * to be validated as part of the signature operation. The values of the given attributes will be part of the signer
-     * name field as they appear in the list (separated by a blank). It is possible to change how the information is
-     * displayed by assigning a formatting, see {@link #setFormatting(String)}.
-     * 
-     * @param signerAttributes
-     *          a list of attribute names whose values should be used to display the signer name in the visible PDF
-     *          signature
-     * @return a list of attribute names whose values should be used to display the signer name in the visible PDF
-     *         signature
-     */
-    @Getter
-    @Setter
-    @Singular
-    private List<SignerIdentityAttribute> signerAttributes;
-
-    /**
-     * Optional string the may be supplied to change how the signer's information is displayed. Each list item from
-     * {@link #getSignerAttributes()} is referenced by its order (starting from 0) and prefixed by %. For example, the
-     * formatting string {@code "%1 %2 (%3)"} may display something like {@code Jim Smith (ID12345)}.
-     * 
-     * @param formatting
-     *          the formatting string
-     * @return the formatting string
-     */
-    @Getter
-    @Setter
-    private String formatting;
-
-    /**
-     * Builder for {@code SignerName} objects.
-     */
-    public static class SignerNameBuilder implements ObjectBuilder<SignerName> {
-      // Lombok
+    
+    // Lombok Builder doesn't handle Singular annotations when inheriting ...
+    @java.lang.SuppressWarnings("all")
+    public VisiblePdfSignatureRequirementBuilder fieldValue(final String fieldValueKey, final String fieldValueValue) {
+      if (this.fieldValues == null) {
+        this.fieldValues = new HashMap<>();
+      }
+      this.fieldValues.put(fieldValueKey, fieldValueValue);
+      return this;
     }
-
   }
+
 }

--- a/src/main/java/se/idsec/signservice/integration/document/pdf/VisiblePdfSignatureRequirementTemplate.java
+++ b/src/main/java/se/idsec/signservice/integration/document/pdf/VisiblePdfSignatureRequirementTemplate.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2019-2020 IDsec Solutions AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package se.idsec.signservice.integration.document.pdf;
+
+import java.util.List;
+import java.util.Map;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.Singular;
+import lombok.ToString;
+import se.idsec.signservice.integration.authentication.AuthnRequirements;
+import se.idsec.signservice.integration.authentication.SignerIdentityAttribute;
+import se.idsec.signservice.integration.core.Extensible;
+import se.idsec.signservice.integration.core.Extension;
+import se.idsec.signservice.integration.core.ObjectBuilder;
+
+/**
+ * Representation of a template for creating a {@link VisiblePdfSignatureRequirement} object. 
+ *
+ * @author Martin Lindström (martin@idsec.se)
+ * @author Stefan Santesson (stefan@idsec.se)
+ */
+@ToString
+@Builder(builderMethodName = "toBuilder")
+@NoArgsConstructor
+@AllArgsConstructor
+public class VisiblePdfSignatureRequirementTemplate implements Extensible {
+
+  /**
+   * Name of the signer to be represented in the visible image. This is typically a name of the signer but any suitable
+   * identity attribute value may be specified to be part of the signer name. This value is analogous to, and should
+   * hold the same value as, a present Name entry in the PDF signature dictionary. If the image template referenced
+   * requires a value for signerName, this field is mandatory, otherwise it is optional.
+   * 
+   * @param signerName
+   *          the signer name
+   * @return the signer name
+   */
+  @Getter
+  @Setter
+  private SignerName signerName;
+
+  /**
+   * Apart from the signer name and signing date, a template may use other fields. This map provides the requested
+   * fields and values.
+   * 
+   * @param fieldValues
+   *          a map of fields and their values
+   * @return a map of fields and their values
+   */
+  @Getter
+  @Setter
+  @Singular
+  private Map<String, String> fieldValues;
+
+  /** Extensions for the object. */
+  protected Extension extension;
+
+  /** {@inheritDoc} */
+  @Override
+  public void setExtension(final Extension extension) {
+    this.extension = extension;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Extension getExtension() {
+    return this.extension;
+  }
+
+  /**
+   * Builder for {@code VisiblePdfSignatureRequirement} objects.
+   */
+  public static class VisiblePdfSignatureRequirementTemplateBuilder implements ObjectBuilder<VisiblePdfSignatureRequirementTemplate> {
+    // Lombok
+  }
+
+  /**
+   * Class representing the input needed to display the signer name in a visible PDF signature.
+   */
+  @ToString
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class SignerName {
+
+    /**
+     * A list of attribute names that refer to some, or all, attributes supplied in
+     * {@link AuthnRequirements#setRequestedSignerAttributes(List)} that are the requirements that the signer requires
+     * to be validated as part of the signature operation. The values of the given attributes will be part of the signer
+     * name field as they appear in the list (separated by a blank). It is possible to change how the information is
+     * displayed by assigning a formatting, see {@link #setFormatting(String)}.
+     * 
+     * @param signerAttributes
+     *          a list of attribute names whose values should be used to display the signer name in the visible PDF
+     *          signature
+     * @return a list of attribute names whose values should be used to display the signer name in the visible PDF
+     *         signature
+     */
+    @Getter
+    @Setter
+    @Singular
+    private List<SignerIdentityAttribute> signerAttributes;
+
+    /**
+     * Optional string the may be supplied to change how the signer's information is displayed. Each list item from
+     * {@link #getSignerAttributes()} is referenced by its order (starting from 0) and prefixed by %. For example, the
+     * formatting string {@code "%1 %2 (%3)"} may display something like {@code Jim Smith (ID12345)}.
+     * 
+     * @param formatting
+     *          the formatting string
+     * @return the formatting string
+     */
+    @Getter
+    @Setter
+    private String formatting;
+
+    /**
+     * Builder for {@code SignerName} objects.
+     */
+    public static class SignerNameBuilder implements ObjectBuilder<SignerName> {
+      // Lombok
+    }
+
+  }
+}

--- a/src/main/java/se/idsec/signservice/integration/document/pdf/VisiblePdfSignatureUserInformation.java
+++ b/src/main/java/se/idsec/signservice/integration/document/pdf/VisiblePdfSignatureUserInformation.java
@@ -32,7 +32,7 @@ import se.idsec.signservice.integration.core.Extension;
 import se.idsec.signservice.integration.core.ObjectBuilder;
 
 /**
- * Representation of a template for creating a {@link VisiblePdfSignatureRequirement} object. 
+ * Representation of the user information that is injected into a PDF signature image. 
  *
  * @author Martin Lindström (martin@idsec.se)
  * @author Stefan Santesson (stefan@idsec.se)
@@ -41,7 +41,7 @@ import se.idsec.signservice.integration.core.ObjectBuilder;
 @Builder(builderMethodName = "toBuilder")
 @NoArgsConstructor
 @AllArgsConstructor
-public class VisiblePdfSignatureRequirementTemplate implements Extensible {
+public class VisiblePdfSignatureUserInformation implements Extensible {
 
   /**
    * Name of the signer to be represented in the visible image. This is typically a name of the signer but any suitable
@@ -86,9 +86,9 @@ public class VisiblePdfSignatureRequirementTemplate implements Extensible {
   }
 
   /**
-   * Builder for {@code VisiblePdfSignatureRequirement} objects.
+   * Builder for {@code VisiblePdfSignatureUserInformation} objects.
    */
-  public static class VisiblePdfSignatureRequirementTemplateBuilder implements ObjectBuilder<VisiblePdfSignatureRequirementTemplate> {
+  public static class VisiblePdfSignatureUserInformationBuilder implements ObjectBuilder<VisiblePdfSignatureUserInformation> {
     // Lombok
   }
 

--- a/src/test/java/se/idsec/signservice/integration/SignRequestInputTest.java
+++ b/src/test/java/se/idsec/signservice/integration/SignRequestInputTest.java
@@ -39,7 +39,7 @@ import se.idsec.signservice.integration.document.TbsDocument;
 import se.idsec.signservice.integration.document.TbsDocument.AdesType;
 import se.idsec.signservice.integration.document.TbsDocument.EtsiAdesRequirement;
 import se.idsec.signservice.integration.document.pdf.VisiblePdfSignatureRequirement;
-import se.idsec.signservice.integration.document.pdf.VisiblePdfSignatureRequirementTemplate.SignerName;
+import se.idsec.signservice.integration.document.pdf.VisiblePdfSignatureUserInformation.SignerName;
 import se.idsec.signservice.integration.signmessage.SignMessageMimeType;
 import se.idsec.signservice.integration.signmessage.SignMessageParameters;
 

--- a/src/test/java/se/idsec/signservice/integration/SignRequestInputTest.java
+++ b/src/test/java/se/idsec/signservice/integration/SignRequestInputTest.java
@@ -39,7 +39,7 @@ import se.idsec.signservice.integration.document.TbsDocument;
 import se.idsec.signservice.integration.document.TbsDocument.AdesType;
 import se.idsec.signservice.integration.document.TbsDocument.EtsiAdesRequirement;
 import se.idsec.signservice.integration.document.pdf.VisiblePdfSignatureRequirement;
-import se.idsec.signservice.integration.document.pdf.VisiblePdfSignatureRequirement.SignerName;
+import se.idsec.signservice.integration.document.pdf.VisiblePdfSignatureRequirementTemplate.SignerName;
 import se.idsec.signservice.integration.signmessage.SignMessageMimeType;
 import se.idsec.signservice.integration.signmessage.SignMessageParameters;
 


### PR DESCRIPTION
Extended the API with the preparePdfSignaturePage() method. This method can be used by a RP to prepare a PDF document that is to contain one or more PDF signature image(s) with a PDF signature page.