### PR TITLE
Add time zone support to PDF templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ Read more at the [API documentation](https://idsec-solutions.github.io/signservi
 
 ---
 
-Copyright &copy; 2019-2024, [IDsec Solutions AB](http://www.idsec.se). Licensed under version 2.0 of the [Apache License](http://www.apache.org/licenses/LICENSE-2.0).
+Copyright &copy; 2019-2025, [IDsec Solutions AB](http://www.idsec.se). Licensed under version 2.0 of the [Apache License](http://www.apache.org/licenses/LICENSE-2.0).

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,4 +41,4 @@ Please create an [Issue](https://github.com/idsec-solutions/signservice-integrat
 
 ---
 
-Copyright &copy; 2019-2024, [IDsec Solutions AB](http://www.idsec.se). Licensed under version 2.0 of the [Apache License](http://www.apache.org/licenses/LICENSE-2.0).
+Copyright &copy; 2019-2025, [IDsec Solutions AB](http://www.idsec.se). Licensed under version 2.0 of the [Apache License](http://www.apache.org/licenses/LICENSE-2.0).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -174,4 +174,4 @@ Note:
 
 ---
 
-Copyright &copy; 2019-2024, [IDsec Solutions AB](http://www.idsec.se). Licensed under version 2.0 of the [Apache License](http://www.apache.org/licenses/LICENSE-2.0).
+Copyright &copy; 2019-2025, [IDsec Solutions AB](http://www.idsec.se). Licensed under version 2.0 of the [Apache License](http://www.apache.org/licenses/LICENSE-2.0).

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -117,4 +117,4 @@ The `internal` category represents "internal errors" of the service. Errors of t
 
 ---
 
-Copyright &copy; 2019-2024, [IDsec Solutions AB](http://www.idsec.se). Licensed under version 2.0 of the [Apache License](http://www.apache.org/licenses/LICENSE-2.0).
+Copyright &copy; 2019-2025, [IDsec Solutions AB](http://www.idsec.se). Licensed under version 2.0 of the [Apache License](http://www.apache.org/licenses/LICENSE-2.0).

--- a/docs/java-api.md
+++ b/docs/java-api.md
@@ -189,4 +189,4 @@ TODO
 
 ---
 
-Copyright &copy; 2019-2024, [IDsec Solutions AB](http://www.idsec.se). Licensed under version 2.0 of the [Apache License](http://www.apache.org/licenses/LICENSE-2.0).
+Copyright &copy; 2019-2025, [IDsec Solutions AB](http://www.idsec.se). Licensed under version 2.0 of the [Apache License](http://www.apache.org/licenses/LICENSE-2.0).

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -253,4 +253,4 @@ TODO
 
 ---
 
-Copyright &copy; 2019-2024, [IDsec Solutions AB](http://www.idsec.se). Licensed under version 2.0 of the [Apache License](http://www.apache.org/licenses/LICENSE-2.0).
+Copyright &copy; 2019-2025, [IDsec Solutions AB](http://www.idsec.se). Licensed under version 2.0 of the [Apache License](http://www.apache.org/licenses/LICENSE-2.0).

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -12,4 +12,4 @@ TODO
 
 ---
 
-Copyright &copy; 2019-2024, [IDsec Solutions AB](http://www.idsec.se). Licensed under version 2.0 of the [Apache License](http://www.apache.org/licenses/LICENSE-2.0).
+Copyright &copy; 2019-2025, [IDsec Solutions AB](http://www.idsec.se). Licensed under version 2.0 of the [Apache License](http://www.apache.org/licenses/LICENSE-2.0).

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>se.idsec.signservice.integration</groupId>
   <artifactId>signservice-integration-api</artifactId>
-  <version>2.3.0</version>
+  <version>2.3.1-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>IDsec Solutions :: SignService :: Integration API</name>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>17</java.version>
 
-    <jackson.version>2.18.2</jackson.version>
+    <jackson.version>2.18.3</jackson.version>
   </properties>
 
   <distributionManagement>
@@ -102,7 +102,7 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>5.11.3</version>
+      <version>5.12.0</version>
       <scope>test</scope>
     </dependency>
 
@@ -162,7 +162,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.10.0</version>
+        <version>3.10.1</version>
         <configuration>
           <doctitle>SignService Integration API - ${project.version}</doctitle>
           <windowtitle>SignService Integration API - ${project.version}</windowtitle>

--- a/src/main/java/se/idsec/signservice/integration/ApiVersion.java
+++ b/src/main/java/se/idsec/signservice/integration/ApiVersion.java
@@ -24,7 +24,7 @@ public final class ApiVersion {
 
   private static final int MAJOR = 2;
   private static final int MINOR = 3;
-  private static final int PATCH = 0;
+  private static final int PATCH = 1;
 
   /**
    * Gets the version string.

--- a/src/main/java/se/idsec/signservice/integration/document/pdf/PdfSignatureImageTemplate.java
+++ b/src/main/java/se/idsec/signservice/integration/document/pdf/PdfSignatureImageTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 IDsec Solutions AB
+ * Copyright 2019-2025 IDsec Solutions AB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,9 +30,10 @@ import se.idsec.signservice.integration.core.ObjectBuilder;
 
 import java.io.Serial;
 import java.nio.charset.StandardCharsets;
+import java.text.SimpleDateFormat;
+import java.time.ZoneId;
 import java.util.Base64;
 import java.util.Map;
-import java.util.TimeZone;
 
 /**
  * Representation of an image template that is used for visible PDF signatures.
@@ -101,7 +102,15 @@ public class PdfSignatureImageTemplate implements Extensible {
   @Builder.Default
   private boolean includeSigningTime = false;
 
+  /**
+   * The time zone to use for signing time.
+   */
   private String timeZoneId;
+
+  /**
+   * The Java date format to use for signing time.
+   */
+  private String dateFormat;
 
   /**
    * A map of the field names that are required by the template in the fieldName map in
@@ -299,16 +308,61 @@ public class PdfSignatureImageTemplate implements Extensible {
    * @return the time zone identifier
    */
   public String getTimeZoneId() {
-    return timeZoneId;
+    return this.timeZoneId;
   }
 
   /**
-   * Assigns the time zone identifier for this template.
+   * Assigns the time zone identifier for this template. The default is {@code TimeZone.getDefault()}.
    *
    * @param timeZoneId the time zone identifier
+   * @throws IllegalArgumentException for invalid input
    */
-  public void setTimeZoneId(final String timeZoneId) {
+  public void setTimeZoneId(final String timeZoneId) throws IllegalArgumentException {
+    checkTimeZoneId(timeZoneId);
     this.timeZoneId = timeZoneId;
+  }
+
+  private static void checkTimeZoneId(final String timeZoneId) throws IllegalArgumentException {
+    try {
+      if (timeZoneId != null) {
+        ZoneId.of(timeZoneId);
+      }
+    }
+    catch (final Exception e) {
+      throw new IllegalArgumentException("Invalid time zone id: " + timeZoneId, e);
+    }
+  }
+
+  /**
+   * Gets the Java date format to use for signing time strings. See {@link SimpleDateFormat} for valid formats. The
+   * default is {@code yyyy-MM-dd HH:mm z}.
+   *
+   * @return date format string, or {@code null} if not assigned
+   */
+  public String getDateFormat() {
+    return this.dateFormat;
+  }
+
+  /**
+   * Assigns the date format to use for signing time strings.
+   *
+   * @param dateFormat the date format
+   * @throws IllegalArgumentException for invalid input
+   */
+  public void setDateFormat(final String dateFormat) throws IllegalArgumentException {
+    checkDateFormat(dateFormat);
+    this.dateFormat = dateFormat;
+  }
+
+  private static void checkDateFormat(final String dateFormat) throws IllegalArgumentException {
+    try {
+      if (dateFormat != null) {
+        new SimpleDateFormat(dateFormat);
+      }
+    }
+    catch (final Exception e) {
+      throw new IllegalArgumentException("invalid date format: " + dateFormat, e);
+    }
   }
 
   /**
@@ -319,6 +373,18 @@ public class PdfSignatureImageTemplate implements Extensible {
     private boolean includeSignerName = true;
     @SuppressWarnings("unused")
     private boolean includeSigningTime = false;
+
+    public PdfSignatureImageTemplateBuilder timeZoneId(final String timeZoneId) {
+      checkTimeZoneId(timeZoneId);
+      this.timeZoneId = timeZoneId;
+      return this;
+    }
+
+    public PdfSignatureImageTemplateBuilder dateFormat(final String dateFormat) {
+      checkDateFormat(dateFormat);
+      this.dateFormat = dateFormat;
+      return this;
+    }
 
     // Lombok
   }

--- a/src/main/java/se/idsec/signservice/integration/document/pdf/PdfSignatureImageTemplate.java
+++ b/src/main/java/se/idsec/signservice/integration/document/pdf/PdfSignatureImageTemplate.java
@@ -32,6 +32,7 @@ import java.io.Serial;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Map;
+import java.util.TimeZone;
 
 /**
  * Representation of an image template that is used for visible PDF signatures.
@@ -99,6 +100,8 @@ public class PdfSignatureImageTemplate implements Extensible {
    */
   @Builder.Default
   private boolean includeSigningTime = false;
+
+  private String timeZoneId;
 
   /**
    * A map of the field names that are required by the template in the fieldName map in
@@ -288,6 +291,24 @@ public class PdfSignatureImageTemplate implements Extensible {
   @Override
   public void setExtension(final Extension extension) {
     this.extension = extension;
+  }
+
+  /**
+   * Gets the identifier for the time zone associated with this template.
+   *
+   * @return the time zone identifier
+   */
+  public String getTimeZoneId() {
+    return timeZoneId;
+  }
+
+  /**
+   * Assigns the time zone identifier for this template.
+   *
+   * @param timeZoneId the time zone identifier
+   */
+  public void setTimeZoneId(final String timeZoneId) {
+    this.timeZoneId = timeZoneId;
   }
 
   /**


### PR DESCRIPTION
Incremented the API version to 2.3.1-SNAPSHOT to reflect new changes. Introduced a `timeZoneId` field in `PdfSignatureImageTemplate` for better time zone handling. Added relevant getters and setters to support this feature.